### PR TITLE
ci(test): bump action and node LTS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18.17.1
+          node-version: 22.x
       - run: yarn install
       - run: yarn test


### PR DESCRIPTION
- bump actions/checkout from v2 to v4

  [actions/checkout](https://github.com/actions/checkout)

- bump actions/setup-node from v2 to v4

  [actions/setup-node](https://github.com/actions/setup-node)

- bump nodejs from 18.17 to 22.x